### PR TITLE
make RUN_AS/RUN_GRP configurable in /etc/default/openmediavault

### DIFF
--- a/usr/share/openmediavault/mkconf/emby
+++ b/usr/share/openmediavault/mkconf/emby
@@ -20,8 +20,8 @@ set -e
 . /etc/default/openmediavault
 . /usr/share/openmediavault/scripts/helper-functions
 
-RUN_AS="emby"
-RUN_GRP="nogroup"
+RUN_AS=${OMV_EMBY_RUN_AS:-"emby"}
+RUN_GRP=${OMV_EMBY_RUN_GRP:-"nogroup"}
 SERVICE="emby"
 SERVICE_XPATH="//services/${SERVICE}"
 BIN="/usr/local/bin"


### PR DESCRIPTION
hi,
I've changed emby's RUN_AS RUN_GRP variables in my omv server. However the changes gone after every emby upgrade. So I added OMV_EMBY_RUN_AS/OMV_EMBY_RUN_GRP these two variables to /etc/default/openmediavault.
